### PR TITLE
Use the same location for the pharo vm script as in the Makefile

### DIFF
--- a/merge
+++ b/merge
@@ -8,4 +8,4 @@ cd - > /dev/null
 # disable parameter expansion to forward all arguments unprocessed to the VM
 set -f
 # run the VM and pass along all arguments as is
-"$DIR"/"pharo/pharo-vm/pharo" --nodisplay "$DIR"/pharo/Pharo.image --no-default-preferences mergeDriver "$@"
+"$DIR"/"pharo/pharo" --nodisplay "$DIR"/pharo/Pharo.image --no-default-preferences mergeDriver "$@"


### PR DESCRIPTION
This is required to change on Mac OS X. I don't know about other platforms.
