### PR TITLE
mac vm requires the "--headless" parameter instead of the "--nodisplay"

### DIFF
--- a/merge
+++ b/merge
@@ -8,4 +8,4 @@ cd - > /dev/null
 # disable parameter expansion to forward all arguments unprocessed to the VM
 set -f
 # run the VM and pass along all arguments as is
-"$DIR"/"pharo/pharo" --headless  "$DIR"/pharo/Pharo.image --no-default-preferences mergeDriver "$@"
+"$DIR"/"pharo/pharo" "$DIR"/pharo/Pharo.image --no-default-preferences mergeDriver "$@"


### PR DESCRIPTION
This fix is probably not going to work in Linux (I guess) but consider this pull request as a discussion point on how to make the call platform independent.

So, when the "headless" parameter is used on mac os x, the vm startup fails. Is this the case on linux as well?
If we must use the different parameters, I will whip up some platform detection code and try to fix that.

best regards
Johan
