### PR TITLE
Replace the shebang by a standard one

### DIFF
--- a/merge
+++ b/merge
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 # some magic to find out the real location of this script dealing with symlinks
 DIR=`readlink "$0"` || DIR="$0";
 DIR=`dirname "$DIR"`;


### PR DESCRIPTION
Yes, some systems don't have bash in /bin