### PR TITLE
Use PHARO_VM environment when it exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
 #A makefile to build the merge driver
 
+# Use the PHARO_VM environment variable to indicate where to find the
+# Pharo VM. If the environment variable is not set, set it to a newly
+# downloaded VM.
+PHARO_VM ?= 'pharo/pharo'
+
 pharo/Pharo.image:
 	mkdir pharo
 	cd pharo; wget -O- get.pharo.org/30+vm | bash
-	pharo/pharo pharo/Pharo.image --no-default-preferences eval --save Gofer new url: \'http://smalltalkhub.com/mc/ThierryGoubier/Alt30/main/\'\; package: \'GitFileTree-MergeDriver\'\; load
+	$(PHARO_VM) pharo/Pharo.image --no-default-preferences eval --save Gofer new url: \'http://smalltalkhub.com/mc/ThierryGoubier/Alt30/main/\'\; package: \'GitFileTree-MergeDriver\'\; load
 	git config --global merge.mcVersion.driver "`pwd`/merge --version %O %A %B"
 	git config --global merge.mcMethodProperties.name "GitFileTree MergeDriver for Monticello"
 	git config --global merge.mcMethodProperties.driver "`pwd`/merge --methodProperties %O %A %B"

--- a/merge
+++ b/merge
@@ -10,5 +10,10 @@ DIR=`pwd`
 cd - > /dev/null
 # disable parameter expansion to forward all arguments unprocessed to the VM
 set -f
+# Use the PHARO_VM environment variable to indicate where to find the
+# Pharo VM. If the environment variable is not set, set it to a newly
+# downloaded VM.
+PHARO_VM=${PHARO_VM:-$DIR/pharo/pharo}
+
 # run the VM and pass along all arguments as is
-"$DIR"/"pharo/pharo" "$DIR"/pharo/Pharo.image --no-default-preferences mergeDriver "$@"
+"$PHARO_VM" "$DIR"/pharo/Pharo.image --no-default-preferences mergeDriver "$@"


### PR DESCRIPTION
This will make the Makefile work on environments where running a downloaded
binary VM is not going to work (e.g., on nix systems).